### PR TITLE
Changed uart timeout errors to give more detail

### DIFF
--- a/nuhal_all/include/nuhal/uart.h
+++ b/nuhal_all/include/nuhal/uart.h
@@ -7,6 +7,9 @@
 /// @brief generic interface to a uart,
 /// implemented with different uart_<platform>.c files
 
+/// @brief max length of uart port device path
+#define MAX_LENGTH_UART_DEVICE_PATH 4096
+
 /// @brief a description of the port
 struct uart_port;
 
@@ -188,6 +191,11 @@ bool uart_wait_for_data(const struct uart_port * port, uint32_t timeout);
 /// @param port - the uart port to check
 /// @return true if data is available to be read
 bool uart_data_available(const struct uart_port * port);
+
+/// @brief accesses port's device path but prevents it from being modified
+/// @param port - the uart port to get device path from
+/// @return the name/device of the port
+const char * uart_get_device_path(const struct uart_port * port);
 
 #ifdef __cplusplus
 }

--- a/nuhal_all/src/uart.c
+++ b/nuhal_all/src/uart.c
@@ -20,7 +20,7 @@ int uart_read_block_error(const struct uart_port * port, void * data,
     struct time_elapsed_ms stamp = time_elapsed_ms_init();
     // on some platforms we can avoid taking cpu cycles to wait for data
     // in which case uart_wait_for_data is the most efficient way to go.
-    // no need to check if it time d out as the next loop will be skipped
+    // no need to check if it timed out as the next loop will be skipped
     // if it did
     (void)uart_wait_for_data(port, timeout);
     while(timeout == 0 || time_elapsed_ms(&stamp) < timeout)
@@ -62,14 +62,21 @@ int uart_read_block_error(const struct uart_port * port, void * data,
             }
             break;
         default:
-            error(FILE_LINE, "Invalid termination condition");
+            char error_msg[128 + PATH_MAX]; // adjust size as needed
+            snprintf(error_msg, sizeof(error_msg), "Invalid termination condition on UART port %s", port->device_path);
+            error(FILE_LINE, error_msg);
             break;
         }
     }
     // if we get here we have timed out
     if(timeout_error)
     {
-        error(FILE_LINE, "Timeout on blocking read.");
+        char error_msg[128 + PATH_MAX + read]; // adjust size as needed
+        char uart_msg[read + 1];
+        memcpy(uart_msg, data, read);
+        uart_msg[read] = '\0';
+        snprintf(error_msg, sizeof(error_msg), "Timeout on blocking read. Trying to read on UART port %s\nHave read up to: %s\nNumber of bytes left to read: %d", port->device_path, uart_msg, len - read);
+        error(FILE_LINE, error_msg);
     }
     return read;
 }
@@ -96,7 +103,14 @@ int uart_write_block(const struct uart_port * port, const void * data,
         }
     }
     // if we get here we have timed out
-    error(FILE_LINE, "Timeout on blocking write.");
+    char error_msg[128 + PATH_MAX + len]; // adjust size as needed
+    char written_uart_msg[written + 1];
+    char to_write_uart_msg[len - written + 1];
+    memcpy(written_uart_msg, data, written);
+    memcpy(to_write_uart_msg, data + written, len - written);
+    char_buffer[written] = '\0';
+    snprintf(error_msg, sizeof(error_msg), "Timeout on blocking write. Trying to write from UART port %s\nHave written up to: %s\nStill left to write: %s", port->device_path, written_uart_msg, to_write_uart_msg);
+    error(FILE_LINE, error_msg);
     return -1;
 }
 
@@ -108,7 +122,9 @@ int uart_printf(const struct uart_port * port, const char * fmt, ...)
     const int len = vsnprintf(NULL, 0, fmt, args);
     if(len < 0)
     {
-        error(FILE_LINE, "printf encoding error");
+        char error_msg[128 + PATH_MAX]; // adjust size as needed
+        snprintf(error_msg, sizeof(error_msg), "printf encoding error. Trying to print from UART port %s", port->device_path);
+        error(FILE_LINE, error_msg);
     }
 
     // true if the message to be printed fits in the buffer
@@ -147,7 +163,9 @@ int uart_scanf(const struct uart_port * port, const char * fmt, ...)
                                     UART_TERM_CR_OR_LF);
     if(buffer[len - 1] != '\r' && buffer[len - 1] != '\n')
     {
-        error(FILE_LINE, "uart_scanf input too long");
+        char error_msg[128 + PATH_MAX]; // adjust size as needed
+        snprintf(error_msg, sizeof(error_msg), "uart_scanf input too long. Trying to scan from UART port %s", port->device_path);
+        error(FILE_LINE, error_msg);
     }
     va_list args;
     va_start(args, fmt);

--- a/nuhal_all/src/uart.c
+++ b/nuhal_all/src/uart.c
@@ -89,7 +89,7 @@ int uart_read_block_error(const struct uart_port * port, void * data,
 int uart_read_block(const struct uart_port * port, void * data,
                     size_t len, uint32_t timeout, enum uart_term term)
 {
-    return uart_read_block_error(port, data, len, timeout, term, false);
+    return uart_read_block_error(port, data, len, timeout, term, true);
 }
 
 int uart_write_block(const struct uart_port * port, const void * data,

--- a/nuhal_all/src/uart.c
+++ b/nuhal_all/src/uart.c
@@ -33,49 +33,54 @@ int uart_read_block_error(const struct uart_port * port, void * data,
 
         switch(term)
         {
-        case UART_TERM_NONE:
-            ; // no early termination based on a character
-            break;
-        case UART_TERM_CR:
-            if('\r' == ((uint8_t*)data)[read - 1])
+            case UART_TERM_NONE:
+                ; // no early termination based on a character
+                break;
+            case UART_TERM_CR:
+                if('\r' == ((uint8_t*)data)[read - 1])
+                {
+                    return read;
+                }
+                break;
+            case UART_TERM_LF:
+                if('\n' == ((uint8_t*)data)[read-1])
+                {
+                    return read;
+                }
+                break;
+            case UART_TERM_NULL:
+                if('\0' == ((uint8_t*)data)[read-1])
+                {
+                    return read;
+                }
+                break;
+            case UART_TERM_CR_OR_LF:
+                if('\r' == ((uint8_t*)data)[read-1]
+                || '\n' == ((uint8_t*)data)[read-1])
+                {
+                    return read;
+                }
+                break;
+            default:
             {
-                return read;
+                char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
+                snprintf(error_msg, sizeof(error_msg), "Invalid termination condition on UART port %s", uart_get_device_path(port));
+                error(FILE_LINE, error_msg);
+                break;
             }
-            break;
-        case UART_TERM_LF:
-            if('\n' == ((uint8_t*)data)[read-1])
-            {
-                return read;
-            }
-            break;
-        case UART_TERM_NULL:
-            if('\0' == ((uint8_t*)data)[read-1])
-            {
-                return read;
-            }
-            break;
-        case UART_TERM_CR_OR_LF:
-            if('\r' == ((uint8_t*)data)[read-1]
-               || '\n' == ((uint8_t*)data)[read-1])
-            {
-                return read;
-            }
-            break;
-        default:
-            char error_msg[128 + PATH_MAX]; // adjust size as needed
-            snprintf(error_msg, sizeof(error_msg), "Invalid termination condition on UART port %s", port->device_path);
-            error(FILE_LINE, error_msg);
-            break;
         }
     }
+    
     // if we get here we have timed out
     if(timeout_error)
     {
-        char error_msg[128 + PATH_MAX + read]; // adjust size as needed
         char uart_msg[read + 1];
         memcpy(uart_msg, data, read);
         uart_msg[read] = '\0';
-        snprintf(error_msg, sizeof(error_msg), "Timeout on blocking read. Trying to read on UART port %s\nHave read up to: %s\nNumber of bytes left to read: %d", port->device_path, uart_msg, len - read);
+
+        char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH + read]; // adjust size as needed
+        snprintf(error_msg, sizeof(error_msg), "Timeout on blocking read. Trying to read on UART port %s\nHave read up to: %s\nNumber of bytes left to read: %zu", uart_get_device_path(port), uart_msg, len - read);
+
         error(FILE_LINE, error_msg);
     }
     return read;
@@ -103,13 +108,17 @@ int uart_write_block(const struct uart_port * port, const void * data,
         }
     }
     // if we get here we have timed out
-    char error_msg[128 + PATH_MAX + len]; // adjust size as needed
     char written_uart_msg[written + 1];
-    char to_write_uart_msg[len - written + 1];
     memcpy(written_uart_msg, data, written);
-    memcpy(to_write_uart_msg, data + written, len - written);
-    char_buffer[written] = '\0';
-    snprintf(error_msg, sizeof(error_msg), "Timeout on blocking write. Trying to write from UART port %s\nHave written up to: %s\nStill left to write: %s", port->device_path, written_uart_msg, to_write_uart_msg);
+    written_uart_msg[written] = '\0';
+
+    char to_write_uart_msg[len - written + 1];
+    memcpy(to_write_uart_msg, (uint8_t*)data + written, len - written);
+    to_write_uart_msg[len - written] = '\0';
+
+    char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH + len]; // adjust size as needed
+    snprintf(error_msg, sizeof(error_msg), "Timeout on blocking write. Trying to write from UART port %s\nHave written up to: %s\nStill left to write: %s", uart_get_device_path(port), written_uart_msg, to_write_uart_msg);
+
     error(FILE_LINE, error_msg);
     return -1;
 }
@@ -122,8 +131,8 @@ int uart_printf(const struct uart_port * port, const char * fmt, ...)
     const int len = vsnprintf(NULL, 0, fmt, args);
     if(len < 0)
     {
-        char error_msg[128 + PATH_MAX]; // adjust size as needed
-        snprintf(error_msg, sizeof(error_msg), "printf encoding error. Trying to print from UART port %s", port->device_path);
+        char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
+        snprintf(error_msg, sizeof(error_msg), "printf encoding error. Trying to print from UART port %s", uart_get_device_path(port));
         error(FILE_LINE, error_msg);
     }
 
@@ -163,8 +172,8 @@ int uart_scanf(const struct uart_port * port, const char * fmt, ...)
                                     UART_TERM_CR_OR_LF);
     if(buffer[len - 1] != '\r' && buffer[len - 1] != '\n')
     {
-        char error_msg[128 + PATH_MAX]; // adjust size as needed
-        snprintf(error_msg, sizeof(error_msg), "uart_scanf input too long. Trying to scan from UART port %s", port->device_path);
+        char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
+        snprintf(error_msg, sizeof(error_msg), "uart_scanf input too long. Trying to scan from UART port %s", uart_get_device_path(port));
         error(FILE_LINE, error_msg);
     }
     va_list args;

--- a/nuhal_all/test/uart_stub.cpp
+++ b/nuhal_all/test/uart_stub.cpp
@@ -31,3 +31,8 @@ int uart_write_nonblock(const struct uart_port * , const void * , size_t )
 {
     throw std::logic_error("uart_write_nonblock is a stub function");
 }
+
+const char * uart_get_device_path(const struct uart_port * ) 
+{
+    throw std::logic_error("uart_get_device_path is a stub function");
+}

--- a/nuhal_linux/src/uart_host.c
+++ b/nuhal_linux/src/uart_host.c
@@ -44,6 +44,17 @@ struct uart_port
 
 static struct uart_port * port_list_head = NULL;
 
+// accesses port's device path but prevents it from being modified
+const char * uart_get_device_path(const struct uart_port * port)
+{
+    if (!port)
+    {
+        error(FILE_LINE, "NULL uart port");
+    }
+
+    return port->device_path;
+}
+
 // run at exit to close all the uart ports
 static void uart_cleanup(void)
 {

--- a/nuhal_linux/src/uart_host.c
+++ b/nuhal_linux/src/uart_host.c
@@ -127,9 +127,8 @@ const struct uart_port * uart_open(const char name[], uint32_t baud,
     }
     port->is_usb = strncmp("/dev/ttyUSB", realname, 11) == 0
                    || strncmp("/dev/ttyACM", realname, 11) == 0;
-    strncpy(port->device_path, realname, PATH_MAX - 1);
+    strncpy(port->device_path, name, PATH_MAX - 1);
     port->device_path[PATH_MAX - 1] = '\0';
-
 
     // open serial port for non-blocking reads
     port->fd = open(realname, O_RDWR | O_NOCTTY | O_NONBLOCK);

--- a/nuhal_linux/src/uart_host.c
+++ b/nuhal_linux/src/uart_host.c
@@ -30,6 +30,7 @@ struct uart_port
     int fd;   // file descriptor
     bool is_open;
     bool is_usb;
+    char device_path[PATH_MAX];
     struct termios old_tio;
     struct serial_struct old_serial;
 
@@ -115,6 +116,8 @@ const struct uart_port * uart_open(const char name[], uint32_t baud,
     }
     port->is_usb = strncmp("/dev/ttyUSB", realname, 11) == 0
                    || strncmp("/dev/ttyACM", realname, 11) == 0;
+    strncpy(port->device_path, realname, PATH_MAX - 1);
+    port->device_path[PATH_MAX - 1] = '\0';
 
 
     // open serial port for non-blocking reads

--- a/nuhal_tiva/src/uart_tiva.c
+++ b/nuhal_tiva/src/uart_tiva.c
@@ -78,7 +78,9 @@ void uart_passthrough(const struct uart_port * port1,
         UARTRxErrorClear(port1->base);
         if(time_elapsed_ms(&stamp) > timeout && timeout != 0)
         {
-            error(FILE_LINE, "Timeout pending end of break signal.");
+            char error_msg[128 + 2*MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
+            snprintf(error_msg, sizeof(error_msg), "Timeout pending end of break signal. Passthrough occurring through UART ports %s and %s.\n Set timeout period: %ld ms\n", uart_get_device_path(port1), uart_get_device_path(port2), timeout);
+            error(FILE_LINE, error_msg);
         }
     }
 }

--- a/nuhal_tiva/src/uart_tiva.c
+++ b/nuhal_tiva/src/uart_tiva.c
@@ -77,7 +77,9 @@ void uart_passthrough(const struct uart_port * port1,
         UARTRxErrorClear(port1->base);
         if(time_elapsed_ms(&stamp) > timeout && timeout != 0)
         {
-            error(FILE_LINE, "Timeout pending end of break signal");
+            char error_msg[128 + 2*PATH_MAX]; // adjust size as needed
+            snprintf(error_msg, sizeof(error_msg), "Timeout pending end of break signal. UART passthrough between UART port %s and UART port %s", port1->device_path, port2->device_path);
+            error(FILE_LINE, error_msg);
         }
     }
 }

--- a/nuhal_tiva/src/uart_tiva.c
+++ b/nuhal_tiva/src/uart_tiva.c
@@ -20,19 +20,20 @@ struct uart_port
     uint32_t base;      // the base uart register
     uint32_t sysctl;    // the peripheral as per the sysctl module
     uint32_t int_base; // the interrupt value for the interrupt controller
+    char device_path[MAX_LENGTH_UART_DEVICE_PATH];
 };
 /// \endcond
 
 // list of the ports that can be opened
 static const struct uart_port ports[] = {
-    {UART0_BASE, SYSCTL_PERIPH_UART0, INT_UART0},
-    {UART1_BASE, SYSCTL_PERIPH_UART1, INT_UART1},
-    {UART2_BASE, SYSCTL_PERIPH_UART2, INT_UART2},
-    {UART3_BASE, SYSCTL_PERIPH_UART3, INT_UART3},
-    {UART4_BASE, SYSCTL_PERIPH_UART4, INT_UART4},
-    {UART5_BASE, SYSCTL_PERIPH_UART5, INT_UART5},
-    {UART6_BASE, SYSCTL_PERIPH_UART6, INT_UART6},
-    {UART7_BASE, SYSCTL_PERIPH_UART7, INT_UART7}
+    {UART0_BASE, SYSCTL_PERIPH_UART0, INT_UART0, "UART0"},
+    {UART1_BASE, SYSCTL_PERIPH_UART1, INT_UART1, "UART1"},
+    {UART2_BASE, SYSCTL_PERIPH_UART2, INT_UART2, "UART2"},
+    {UART3_BASE, SYSCTL_PERIPH_UART3, INT_UART3, "UART3"},
+    {UART4_BASE, SYSCTL_PERIPH_UART4, INT_UART4, "UART4"},
+    {UART5_BASE, SYSCTL_PERIPH_UART5, INT_UART5, "UART5"},
+    {UART6_BASE, SYSCTL_PERIPH_UART6, INT_UART6, "UART6"},
+    {UART7_BASE, SYSCTL_PERIPH_UART7, INT_UART7, "UART7"}
 };
 
 void uart_passthrough(const struct uart_port * port1,
@@ -77,9 +78,7 @@ void uart_passthrough(const struct uart_port * port1,
         UARTRxErrorClear(port1->base);
         if(time_elapsed_ms(&stamp) > timeout && timeout != 0)
         {
-            char error_msg[128 + 2*PATH_MAX]; // adjust size as needed
-            snprintf(error_msg, sizeof(error_msg), "Timeout pending end of break signal. UART passthrough between UART port %s and UART port %s", port1->device_path, port2->device_path);
-            error(FILE_LINE, error_msg);
+            error(FILE_LINE, "Timeout pending end of break signal.");
         }
     }
 }
@@ -314,4 +313,14 @@ void uart_send_break(const struct uart_port * port, uint32_t timeout)
         time_delay_ms(timeout/2);
     }
     UARTBreakCtl(port->base, false);
+}
+
+const char * uart_get_device_path(const struct uart_port * port)
+{
+    if (!port)
+    {
+        error(FILE_LINE, "NULL uart port");
+    }
+
+    return port->device_path;
 }

--- a/nuhal_tiva/src/uart_tiva.c
+++ b/nuhal_tiva/src/uart_tiva.c
@@ -80,7 +80,7 @@ void uart_passthrough(const struct uart_port * port1,
         {
             char error_msg[128 + 2*MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
             snprintf(error_msg, sizeof(error_msg), "Timeout pending end of break signal. Passthrough occurring through UART ports %s and %s.\n Set timeout period: %ld ms\n", uart_get_device_path(port1), uart_get_device_path(port2), timeout);
-            error(FILE_LINE, error_msg);
+            error(FILE_LINE, error_msg); // was not tested and may never be needed since NUC may permanently not need to passthrough main
         }
     }
 }


### PR DESCRIPTION
Features:
- prints out which port triggered the uart error message
- prints out portion of message that was able to be read
- prints out number of bytes left that it still expects to receive

Note:
uart_passthrough error message was not tested and may never be needed since NUC will never need to passthrough main