### PR TITLE
Fixed all requested changes on PR #14

### DIFF
--- a/nuhal_all/include/nuhal/error.h
+++ b/nuhal_all/include/nuhal/error.h
@@ -9,6 +9,7 @@
 
 #include "nuhal/utilities.h"
 #include <stdbool.h>
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,9 +20,10 @@ extern "C" {
 /// recursive calls to error.  If a function used in the error handler
 /// itself calls error, than the error function terminates the program
 /// @param fileline: the FILE_LINE macro, current file and line number
-/// @param msg: additional error information
+/// @param format: formatted C-style string
+/// @param ...: variable number of arguments to be placed into format
 /// @post whether the program loops forever or exits is platform dependent
-void error(const char * fileline, const char * msg) __attribute__((noreturn));
+void error(const char * fileline, const char * fomrat, ...) __attribute__((noreturn));
 
 /// @brief a platform-dependent function that handles the error message
 /// @param fileline - filename and line-number where the error was triggered

--- a/nuhal_all/include/nuhal/error.h
+++ b/nuhal_all/include/nuhal/error.h
@@ -23,7 +23,7 @@ extern "C" {
 /// @param format: formatted C-style string
 /// @param ...: variable number of arguments to be placed into format
 /// @post whether the program loops forever or exits is platform dependent
-void error(const char * fileline, const char * fomrat, ...) __attribute__((noreturn));
+void error(const char * fileline, const char * format, ...) __attribute__((noreturn, format(printf, 2, 3)));
 
 /// @brief a platform-dependent function that handles the error message
 /// @param fileline - filename and line-number where the error was triggered

--- a/nuhal_all/include/nuhal/uart.h
+++ b/nuhal_all/include/nuhal/uart.h
@@ -7,6 +7,9 @@
 /// @brief generic interface to a uart,
 /// implemented with different uart_<platform>.c files
 
+/// @brief max length of uart port device path
+#define MAX_LENGTH_UART_DEVICE_PATH 4096
+
 /// @brief a description of the port
 struct uart_port;
 
@@ -188,6 +191,11 @@ bool uart_wait_for_data(const struct uart_port * port, uint32_t timeout);
 /// @param port - the uart port to check
 /// @return true if data is available to be read
 bool uart_data_available(const struct uart_port * port);
+
+/// @brief accesses port's device path but prevents it from being modified
+/// @param port - the uart port to get device path from
+/// @return the name/device of the port
+const char * uart_get_device_path(const struct uart_port * port);
 
 #ifdef __cplusplus
 }

--- a/nuhal_all/include/nuhal/uart.h
+++ b/nuhal_all/include/nuhal/uart.h
@@ -195,6 +195,7 @@ bool uart_data_available(const struct uart_port * port);
 /// @brief accesses port's device path but prevents it from being modified
 /// @param port - the uart port to get device path from
 /// @return the name/device of the port
+/// @post returned char pointer remains valid as long as param uart_port* remains valid
 const char * uart_get_device_path(const struct uart_port * port);
 
 #ifdef __cplusplus

--- a/nuhal_all/include/nuhal/uart.h
+++ b/nuhal_all/include/nuhal/uart.h
@@ -8,7 +8,7 @@
 /// implemented with different uart_<platform>.c files
 
 /// @brief max length of uart port device path
-#define MAX_LENGTH_UART_DEVICE_PATH 4096
+#define MAX_LENGTH_UART_DEVICE_PATH 8
 
 /// @brief a description of the port
 struct uart_port;

--- a/nuhal_all/src/error.c
+++ b/nuhal_all/src/error.c
@@ -8,7 +8,7 @@
 
 void error_with_errno(const char * fileline)
 {
-    error(fileline, strerror(errno));
+    error(fileline, "%s", strerror(errno));
 }
 
 // sometimes an error somewhere else can trigger another

--- a/nuhal_all/src/error.c
+++ b/nuhal_all/src/error.c
@@ -3,6 +3,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdarg.h>
+#include <stdio.h>
 
 void error_with_errno(const char * fileline)
 {
@@ -13,20 +15,73 @@ void error_with_errno(const char * fileline)
 // error message. we want to stop recursive error calls
 static bool error_called = false;
 
-void error(const char * fileline, const char * msg)
+void error(const char * fileline, const char * format, ...)
 {
     static bool fatal_error_called = false;
+
     if(!error_called)
     {
         error_called = true;
+        va_list args;
+        va_start(args, format);
+
+        // determine required size because read length or write length might be greater than standard 1024 buffer size
+        va_list args_copy;
+        va_copy(args_copy, args);
+        int needed = vsnprintf(NULL, 0, format, args_copy);
+        va_end(args_copy);
+
+        if (needed < 0) {
+            va_end(args);
+            error_handler(fileline, "Invalid formatted error message");
+            exit(EXIT_FAILURE);
+        }
+
+        // allocate buffer (stack or heap)
+        char *msg = malloc((size_t)needed + 1);
+        if (!msg) {
+            va_end(args);
+            error_handler(fileline, "Unable to allocate memory for error message");
+            exit(EXIT_FAILURE);
+        }
+
+        vsnprintf(msg, (size_t)needed + 1, format, args);
+        va_end(args);
         error_handler(fileline, msg);
+        free(msg);
         exit(EXIT_FAILURE);
     }
 
     if(!fatal_error_called)
     {
         fatal_error_called = true;
+        va_list args;
+        va_start(args, format);
+
+        // determine required size because read length or write length might be greater than standard 1024 buffer size
+        va_list args_copy;
+        va_copy(args_copy, args);
+        int needed = vsnprintf(NULL, 0, format, args_copy);
+        va_end(args_copy);
+
+        if (needed < 0) {
+            va_end(args);
+            error_handler_fatal(fileline, "Invalid formatted error message");
+            exit(EXIT_FAILURE);
+        }
+
+        // allocate buffer (stack or heap)
+        char *msg = malloc((size_t)needed + 1);
+        if (!msg) {
+            va_end(args);
+            error_handler_fatal(fileline, "Unable to allocate memory for error message");
+            exit(EXIT_FAILURE);
+        }
+
+        vsnprintf(msg, (size_t)needed + 1, format, args);
+        va_end(args);
         error_handler_fatal(fileline, msg);
+        free(msg);
         exit(EXIT_FAILURE);
     }
 

--- a/nuhal_all/src/error.c
+++ b/nuhal_all/src/error.c
@@ -19,69 +19,24 @@ void error(const char * fileline, const char * format, ...)
 {
     static bool fatal_error_called = false;
 
+    char msg[1024] = "";
+
+    va_list args;
+    va_start(args, format);
+    vsnprintf(msg, sizeof(msg), format, args);
+    va_end(args);
+    
     if(!error_called)
     {
         error_called = true;
-        va_list args;
-        va_start(args, format);
-
-        // determine required size because read length or write length might be greater than standard 1024 buffer size
-        va_list args_copy;
-        va_copy(args_copy, args);
-        int needed = vsnprintf(NULL, 0, format, args_copy);
-        va_end(args_copy);
-
-        if (needed < 0) {
-            va_end(args);
-            error_handler(fileline, "Invalid formatted error message");
-            exit(EXIT_FAILURE);
-        }
-
-        // allocate buffer (stack or heap)
-        char *msg = malloc((size_t)needed + 1);
-        if (!msg) {
-            va_end(args);
-            error_handler(fileline, "Unable to allocate memory for error message");
-            exit(EXIT_FAILURE);
-        }
-
-        vsnprintf(msg, (size_t)needed + 1, format, args);
-        va_end(args);
         error_handler(fileline, msg);
-        free(msg);
         exit(EXIT_FAILURE);
     }
 
     if(!fatal_error_called)
     {
         fatal_error_called = true;
-        va_list args;
-        va_start(args, format);
-
-        // determine required size because read length or write length might be greater than standard 1024 buffer size
-        va_list args_copy;
-        va_copy(args_copy, args);
-        int needed = vsnprintf(NULL, 0, format, args_copy);
-        va_end(args_copy);
-
-        if (needed < 0) {
-            va_end(args);
-            error_handler_fatal(fileline, "Invalid formatted error message");
-            exit(EXIT_FAILURE);
-        }
-
-        // allocate buffer (stack or heap)
-        char *msg = malloc((size_t)needed + 1);
-        if (!msg) {
-            va_end(args);
-            error_handler_fatal(fileline, "Unable to allocate memory for error message");
-            exit(EXIT_FAILURE);
-        }
-
-        vsnprintf(msg, (size_t)needed + 1, format, args);
-        va_end(args);
         error_handler_fatal(fileline, msg);
-        free(msg);
         exit(EXIT_FAILURE);
     }
 

--- a/nuhal_all/src/protocol.c
+++ b/nuhal_all/src/protocol.c
@@ -226,10 +226,10 @@ bool protocol_read_block_error(const struct uart_port * port,
     protocol_packet_stream_init(out);
 
     // read the header
-    uart_read_block(port, &out->_data[0], HEADER_BYTES,
+    uart_read_block_error(port, &out->_data[0], HEADER_BYTES,
                     0 == timeout ? 0
                     : timeout + TIMEOUT_MS_PER_BYTE * HEADER_BYTES ,
-                    UART_TERM_NONE);
+                    UART_TERM_NONE, timeout_error);
 
     // ACK packets from the bootloader have a length of 0, so that length
     // does not include the header bytes. In all other packets, the length

--- a/nuhal_all/src/uart.c
+++ b/nuhal_all/src/uart.c
@@ -20,7 +20,7 @@ int uart_read_block_error(const struct uart_port * port, void * data,
     struct time_elapsed_ms stamp = time_elapsed_ms_init();
     // on some platforms we can avoid taking cpu cycles to wait for data
     // in which case uart_wait_for_data is the most efficient way to go.
-    // no need to check if it time d out as the next loop will be skipped
+    // no need to check if it timed out as the next loop will be skipped
     // if it did
     (void)uart_wait_for_data(port, timeout);
     while(timeout == 0 || time_elapsed_ms(&stamp) < timeout)
@@ -62,14 +62,21 @@ int uart_read_block_error(const struct uart_port * port, void * data,
             }
             break;
         default:
-            error(FILE_LINE, "Invalid termination condition");
+            char error_msg[128 + PATH_MAX]; // adjust size as needed
+            snprintf(error_msg, sizeof(error_msg), "Invalid termination condition on UART port %s", port->device_path);
+            error(FILE_LINE, error_msg);
             break;
         }
     }
     // if we get here we have timed out
     if(timeout_error)
     {
-        error(FILE_LINE, "Timeout on blocking read.");
+        char error_msg[128 + PATH_MAX + read]; // adjust size as needed
+        char uart_msg[read + 1];
+        memcpy(uart_msg, data, read);
+        uart_msg[read] = '\0';
+        snprintf(error_msg, sizeof(error_msg), "Timeout on blocking read. Trying to read on UART port %s\nHave read up to: %s\nNumber of bytes left to read: %d", port->device_path, uart_msg, len - read);
+        error(FILE_LINE, error_msg);
     }
     return read;
 }
@@ -96,7 +103,14 @@ int uart_write_block(const struct uart_port * port, const void * data,
         }
     }
     // if we get here we have timed out
-    error(FILE_LINE, "Timeout on blocking write.");
+    char error_msg[128 + PATH_MAX + len]; // adjust size as needed
+    char written_uart_msg[written + 1];
+    char to_write_uart_msg[len - written + 1];
+    memcpy(written_uart_msg, data, written);
+    memcpy(to_write_uart_msg, data + written, len - written);
+    char_buffer[written] = '\0';
+    snprintf(error_msg, sizeof(error_msg), "Timeout on blocking write. Trying to write from UART port %s\nHave written up to: %s\nStill left to write: %s", port->device_path, written_uart_msg, to_write_uart_msg);
+    error(FILE_LINE, error_msg);
     return -1;
 }
 
@@ -108,7 +122,9 @@ int uart_printf(const struct uart_port * port, const char * fmt, ...)
     const int len = vsnprintf(NULL, 0, fmt, args);
     if(len < 0)
     {
-        error(FILE_LINE, "printf encoding error");
+        char error_msg[128 + PATH_MAX]; // adjust size as needed
+        snprintf(error_msg, sizeof(error_msg), "printf encoding error. Trying to print from UART port %s", port->device_path);
+        error(FILE_LINE, error_msg);
     }
 
     // true if the message to be printed fits in the buffer
@@ -147,7 +163,9 @@ int uart_scanf(const struct uart_port * port, const char * fmt, ...)
                                     UART_TERM_CR_OR_LF);
     if(buffer[len - 1] != '\r' && buffer[len - 1] != '\n')
     {
-        error(FILE_LINE, "uart_scanf input too long");
+        char error_msg[128 + PATH_MAX]; // adjust size as needed
+        snprintf(error_msg, sizeof(error_msg), "uart_scanf input too long. Trying to scan from UART port %s", port->device_path);
+        error(FILE_LINE, error_msg);
     }
     va_list args;
     va_start(args, fmt);

--- a/nuhal_all/src/uart.c
+++ b/nuhal_all/src/uart.c
@@ -63,9 +63,7 @@ int uart_read_block_error(const struct uart_port * port, void * data,
                 break;
             default:
             {
-                char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
-                snprintf(error_msg, sizeof(error_msg), "Invalid termination condition on UART port %s", uart_get_device_path(port));
-                error(FILE_LINE, error_msg);
+                error(FILE_LINE, "Invalid termination condition on UART port %s", uart_get_device_path(port));
                 break;
             }
         }
@@ -74,14 +72,18 @@ int uart_read_block_error(const struct uart_port * port, void * data,
     // if we get here we have timed out
     if(timeout_error)
     {
-        char uart_msg[read + 1];
-        memcpy(uart_msg, data, read);
-        uart_msg[read] = '\0';
-
-        char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH + read]; // adjust size as needed
-        snprintf(error_msg, sizeof(error_msg), "Timeout on blocking read. Trying to read on UART port %s\nHave read up to: %s\nNumber of bytes left to read: %zu", uart_get_device_path(port), uart_msg, len - read);
-
-        error(FILE_LINE, error_msg);
+        uint8_t* bytes = (uint8_t *)data;
+        char read_hex_msg[3*read + 1];
+        size_t offset = 0;
+        for (size_t i = 0; i < read; i++)
+        {
+            offset += snprintf(read_hex_msg + offset, sizeof(read_hex_msg) - offset, "%02X ", bytes[i]);
+        }
+        read_hex_msg[offset] = '\0';
+        error(FILE_LINE, "Timeout on blocking read. Trying to read on UART port %s\nHave read up to: %s (in hex)\nNumber of bytes left to read: %zu", 
+            uart_get_device_path(port), 
+            read_hex_msg, 
+            len - read);
     }
     return read;
 }
@@ -108,18 +110,28 @@ int uart_write_block(const struct uart_port * port, const void * data,
         }
     }
     // if we get here we have timed out
-    char written_uart_msg[written + 1];
-    memcpy(written_uart_msg, data, written);
-    written_uart_msg[written] = '\0';
+    uint8_t* bytes = (uint8_t *)data;
 
-    char to_write_uart_msg[len - written + 1];
-    memcpy(to_write_uart_msg, (uint8_t*)data + written, len - written);
-    to_write_uart_msg[len - written] = '\0';
+    char written_hex_msg[3*written + 1];
+    size_t offset = 0;
+    for (size_t i = 0; i < written; i++)
+    {
+        offset += snprintf(written_hex_msg + offset, sizeof(written_hex_msg) - offset, "%02X ", bytes[i]);
+    }
+    written_hex_msg[offset] = '\0';
 
-    char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH + len]; // adjust size as needed
-    snprintf(error_msg, sizeof(error_msg), "Timeout on blocking write. Trying to write from UART port %s\nHave written up to: %s\nStill left to write: %s", uart_get_device_path(port), written_uart_msg, to_write_uart_msg);
+    char to_write_hex_msg[3*(len - written) + 1];
+    offset = 0;
+    for (size_t i = written; i < len; i++)
+    {
+        offset += snprintf(to_write_hex_msg + offset, sizeof(to_write_hex_msg) - offset, "%02X ", bytes[i]);
+    }
+    to_write_hex_msg[offset] = '\0';
 
-    error(FILE_LINE, error_msg);
+    error(FILE_LINE, "Timeout on blocking write. Trying to write from UART port %s\nHave written up to: %s (in hex)\nStill left to write: %s(in hex)", 
+        uart_get_device_path(port), 
+        written_hex_msg, 
+        to_write_hex_msg);
     return -1;
 }
 
@@ -131,9 +143,7 @@ int uart_printf(const struct uart_port * port, const char * fmt, ...)
     const int len = vsnprintf(NULL, 0, fmt, args);
     if(len < 0)
     {
-        char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
-        snprintf(error_msg, sizeof(error_msg), "printf encoding error. Trying to print from UART port %s", uart_get_device_path(port));
-        error(FILE_LINE, error_msg);
+        error(FILE_LINE, "printf encoding error. Trying to print from UART port %s", uart_get_device_path(port));
     }
 
     // true if the message to be printed fits in the buffer
@@ -172,9 +182,7 @@ int uart_scanf(const struct uart_port * port, const char * fmt, ...)
                                     UART_TERM_CR_OR_LF);
     if(buffer[len - 1] != '\r' && buffer[len - 1] != '\n')
     {
-        char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
-        snprintf(error_msg, sizeof(error_msg), "uart_scanf input too long. Trying to scan from UART port %s", uart_get_device_path(port));
-        error(FILE_LINE, error_msg);
+        error(FILE_LINE, "uart_scanf input too long. Trying to scan from UART port %s", uart_get_device_path(port));
     }
     va_list args;
     va_start(args, fmt);

--- a/nuhal_all/src/uart.c
+++ b/nuhal_all/src/uart.c
@@ -80,7 +80,8 @@ int uart_read_block_error(const struct uart_port * port, void * data,
             offset += snprintf(read_hex_msg + offset, sizeof(read_hex_msg) - offset, "%02X ", bytes[i]);
         }
         read_hex_msg[offset] = '\0';
-        error(FILE_LINE, "Timeout on blocking read. Trying to read on UART port %s\nHave read up to: %s (in hex)\nNumber of bytes left to read: %zu", 
+        error(FILE_LINE, "Timeout (waited %lu ms) on blocking read. Trying to read on UART port %s\nHave read up to: %s (in hex)\nNumber of bytes left to read: %zu", 
+            (unsigned long) timeout,
             uart_get_device_path(port), 
             read_hex_msg, 
             len - read);

--- a/nuhal_all/src/uart.c
+++ b/nuhal_all/src/uart.c
@@ -33,49 +33,54 @@ int uart_read_block_error(const struct uart_port * port, void * data,
 
         switch(term)
         {
-        case UART_TERM_NONE:
-            ; // no early termination based on a character
-            break;
-        case UART_TERM_CR:
-            if('\r' == ((uint8_t*)data)[read - 1])
+            case UART_TERM_NONE:
+                ; // no early termination based on a character
+                break;
+            case UART_TERM_CR:
+                if('\r' == ((uint8_t*)data)[read - 1])
+                {
+                    return read;
+                }
+                break;
+            case UART_TERM_LF:
+                if('\n' == ((uint8_t*)data)[read-1])
+                {
+                    return read;
+                }
+                break;
+            case UART_TERM_NULL:
+                if('\0' == ((uint8_t*)data)[read-1])
+                {
+                    return read;
+                }
+                break;
+            case UART_TERM_CR_OR_LF:
+                if('\r' == ((uint8_t*)data)[read-1]
+                || '\n' == ((uint8_t*)data)[read-1])
+                {
+                    return read;
+                }
+                break;
+            default:
             {
-                return read;
+                char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
+                snprintf(error_msg, sizeof(error_msg), "Invalid termination condition on UART port %s", uart_get_device_path(port));
+                error(FILE_LINE, error_msg);
+                break;
             }
-            break;
-        case UART_TERM_LF:
-            if('\n' == ((uint8_t*)data)[read-1])
-            {
-                return read;
-            }
-            break;
-        case UART_TERM_NULL:
-            if('\0' == ((uint8_t*)data)[read-1])
-            {
-                return read;
-            }
-            break;
-        case UART_TERM_CR_OR_LF:
-            if('\r' == ((uint8_t*)data)[read-1]
-               || '\n' == ((uint8_t*)data)[read-1])
-            {
-                return read;
-            }
-            break;
-        default:
-            char error_msg[128 + PATH_MAX]; // adjust size as needed
-            snprintf(error_msg, sizeof(error_msg), "Invalid termination condition on UART port %s", port->device_path);
-            error(FILE_LINE, error_msg);
-            break;
         }
     }
+    
     // if we get here we have timed out
     if(timeout_error)
     {
-        char error_msg[128 + PATH_MAX + read]; // adjust size as needed
         char uart_msg[read + 1];
         memcpy(uart_msg, data, read);
         uart_msg[read] = '\0';
-        snprintf(error_msg, sizeof(error_msg), "Timeout on blocking read. Trying to read on UART port %s\nHave read up to: %s\nNumber of bytes left to read: %d", port->device_path, uart_msg, len - read);
+
+        char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH + read]; // adjust size as needed
+        snprintf(error_msg, sizeof(error_msg), "Timeout on blocking read. Trying to read on UART port %s\nHave read up to: %s\nNumber of bytes left to read: %zu", uart_get_device_path(port), uart_msg, len - read);
+
         error(FILE_LINE, error_msg);
     }
     return read;
@@ -103,13 +108,17 @@ int uart_write_block(const struct uart_port * port, const void * data,
         }
     }
     // if we get here we have timed out
-    char error_msg[128 + PATH_MAX + len]; // adjust size as needed
     char written_uart_msg[written + 1];
-    char to_write_uart_msg[len - written + 1];
     memcpy(written_uart_msg, data, written);
-    memcpy(to_write_uart_msg, data + written, len - written);
-    char_buffer[written] = '\0';
-    snprintf(error_msg, sizeof(error_msg), "Timeout on blocking write. Trying to write from UART port %s\nHave written up to: %s\nStill left to write: %s", port->device_path, written_uart_msg, to_write_uart_msg);
+    written_uart_msg[written] = '\0';
+
+    char to_write_uart_msg[len - written + 1];
+    memcpy(to_write_uart_msg, (uint8_t*)data + written, len - written);
+    to_write_uart_msg[len - written] = '\0';
+
+    char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH + len]; // adjust size as needed
+    snprintf(error_msg, sizeof(error_msg), "Timeout on blocking write. Trying to write from UART port %s\nHave written up to: %s\nStill left to write: %s", uart_get_device_path(port), written_uart_msg, to_write_uart_msg);
+
     error(FILE_LINE, error_msg);
     return -1;
 }
@@ -122,8 +131,8 @@ int uart_printf(const struct uart_port * port, const char * fmt, ...)
     const int len = vsnprintf(NULL, 0, fmt, args);
     if(len < 0)
     {
-        char error_msg[128 + PATH_MAX]; // adjust size as needed
-        snprintf(error_msg, sizeof(error_msg), "printf encoding error. Trying to print from UART port %s", port->device_path);
+        char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
+        snprintf(error_msg, sizeof(error_msg), "printf encoding error. Trying to print from UART port %s", uart_get_device_path(port));
         error(FILE_LINE, error_msg);
     }
 
@@ -163,8 +172,8 @@ int uart_scanf(const struct uart_port * port, const char * fmt, ...)
                                     UART_TERM_CR_OR_LF);
     if(buffer[len - 1] != '\r' && buffer[len - 1] != '\n')
     {
-        char error_msg[128 + PATH_MAX]; // adjust size as needed
-        snprintf(error_msg, sizeof(error_msg), "uart_scanf input too long. Trying to scan from UART port %s", port->device_path);
+        char error_msg[128 + MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
+        snprintf(error_msg, sizeof(error_msg), "uart_scanf input too long. Trying to scan from UART port %s", uart_get_device_path(port));
         error(FILE_LINE, error_msg);
     }
     va_list args;

--- a/nuhal_all/test/uart_stub.cpp
+++ b/nuhal_all/test/uart_stub.cpp
@@ -31,3 +31,8 @@ int uart_write_nonblock(const struct uart_port * , const void * , size_t )
 {
     throw std::logic_error("uart_write_nonblock is a stub function");
 }
+
+const char * uart_get_device_path(const struct uart_port * ) 
+{
+    throw std::logic_error("uart_get_device_path is a stub function");
+}

--- a/nuhal_linux/src/uart_host.c
+++ b/nuhal_linux/src/uart_host.c
@@ -44,6 +44,17 @@ struct uart_port
 
 static struct uart_port * port_list_head = NULL;
 
+// accesses port's device path but prevents it from being modified
+const char * uart_get_device_path(const struct uart_port * port)
+{
+    if (!port)
+    {
+        error(FILE_LINE, "NULL uart port");
+    }
+
+    return port->device_path;
+}
+
 // run at exit to close all the uart ports
 static void uart_cleanup(void)
 {

--- a/nuhal_linux/src/uart_host.c
+++ b/nuhal_linux/src/uart_host.c
@@ -127,9 +127,8 @@ const struct uart_port * uart_open(const char name[], uint32_t baud,
     }
     port->is_usb = strncmp("/dev/ttyUSB", realname, 11) == 0
                    || strncmp("/dev/ttyACM", realname, 11) == 0;
-    strncpy(port->device_path, realname, PATH_MAX - 1);
+    strncpy(port->device_path, name, PATH_MAX - 1);
     port->device_path[PATH_MAX - 1] = '\0';
-
 
     // open serial port for non-blocking reads
     port->fd = open(realname, O_RDWR | O_NOCTTY | O_NONBLOCK);

--- a/nuhal_linux/src/uart_host.c
+++ b/nuhal_linux/src/uart_host.c
@@ -30,6 +30,7 @@ struct uart_port
     int fd;   // file descriptor
     bool is_open;
     bool is_usb;
+    char device_path[PATH_MAX];
     struct termios old_tio;
     struct serial_struct old_serial;
 
@@ -115,6 +116,8 @@ const struct uart_port * uart_open(const char name[], uint32_t baud,
     }
     port->is_usb = strncmp("/dev/ttyUSB", realname, 11) == 0
                    || strncmp("/dev/ttyACM", realname, 11) == 0;
+    strncpy(port->device_path, realname, PATH_MAX - 1);
+    port->device_path[PATH_MAX - 1] = '\0';
 
 
     // open serial port for non-blocking reads

--- a/nuhal_tiva/src/uart_tiva.c
+++ b/nuhal_tiva/src/uart_tiva.c
@@ -78,7 +78,9 @@ void uart_passthrough(const struct uart_port * port1,
         UARTRxErrorClear(port1->base);
         if(time_elapsed_ms(&stamp) > timeout && timeout != 0)
         {
-            error(FILE_LINE, "Timeout pending end of break signal.");
+            char error_msg[128 + 2*MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
+            snprintf(error_msg, sizeof(error_msg), "Timeout pending end of break signal. Passthrough occurring through UART ports %s and %s.\n Set timeout period: %ld ms\n", uart_get_device_path(port1), uart_get_device_path(port2), timeout);
+            error(FILE_LINE, error_msg);
         }
     }
 }

--- a/nuhal_tiva/src/uart_tiva.c
+++ b/nuhal_tiva/src/uart_tiva.c
@@ -78,9 +78,7 @@ void uart_passthrough(const struct uart_port * port1,
         UARTRxErrorClear(port1->base);
         if(time_elapsed_ms(&stamp) > timeout && timeout != 0)
         {
-            char error_msg[128 + 2*MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
-            snprintf(error_msg, sizeof(error_msg), "Timeout pending end of break signal. Passthrough occurring through UART ports %s and %s.\n Set timeout period: %ld ms\n", uart_get_device_path(port1), uart_get_device_path(port2), timeout);
-            error(FILE_LINE, error_msg); // was not tested and may never be needed since NUC may permanently not need to passthrough main
+            error(FILE_LINE, "Timeout pending end of break signal. Passthrough occurring through UART ports %s and %s.\n Set timeout period: %ld ms\n", uart_get_device_path(port1), uart_get_device_path(port2), timeout); // was not tested and may never be needed since NUC may permanently not need to passthrough main
         }
     }
 }

--- a/nuhal_tiva/src/uart_tiva.c
+++ b/nuhal_tiva/src/uart_tiva.c
@@ -77,7 +77,9 @@ void uart_passthrough(const struct uart_port * port1,
         UARTRxErrorClear(port1->base);
         if(time_elapsed_ms(&stamp) > timeout && timeout != 0)
         {
-            error(FILE_LINE, "Timeout pending end of break signal");
+            char error_msg[128 + 2*PATH_MAX]; // adjust size as needed
+            snprintf(error_msg, sizeof(error_msg), "Timeout pending end of break signal. UART passthrough between UART port %s and UART port %s", port1->device_path, port2->device_path);
+            error(FILE_LINE, error_msg);
         }
     }
 }

--- a/nuhal_tiva/src/uart_tiva.c
+++ b/nuhal_tiva/src/uart_tiva.c
@@ -20,19 +20,20 @@ struct uart_port
     uint32_t base;      // the base uart register
     uint32_t sysctl;    // the peripheral as per the sysctl module
     uint32_t int_base; // the interrupt value for the interrupt controller
+    char device_path[MAX_LENGTH_UART_DEVICE_PATH];
 };
 /// \endcond
 
 // list of the ports that can be opened
 static const struct uart_port ports[] = {
-    {UART0_BASE, SYSCTL_PERIPH_UART0, INT_UART0},
-    {UART1_BASE, SYSCTL_PERIPH_UART1, INT_UART1},
-    {UART2_BASE, SYSCTL_PERIPH_UART2, INT_UART2},
-    {UART3_BASE, SYSCTL_PERIPH_UART3, INT_UART3},
-    {UART4_BASE, SYSCTL_PERIPH_UART4, INT_UART4},
-    {UART5_BASE, SYSCTL_PERIPH_UART5, INT_UART5},
-    {UART6_BASE, SYSCTL_PERIPH_UART6, INT_UART6},
-    {UART7_BASE, SYSCTL_PERIPH_UART7, INT_UART7}
+    {UART0_BASE, SYSCTL_PERIPH_UART0, INT_UART0, "UART0"},
+    {UART1_BASE, SYSCTL_PERIPH_UART1, INT_UART1, "UART1"},
+    {UART2_BASE, SYSCTL_PERIPH_UART2, INT_UART2, "UART2"},
+    {UART3_BASE, SYSCTL_PERIPH_UART3, INT_UART3, "UART3"},
+    {UART4_BASE, SYSCTL_PERIPH_UART4, INT_UART4, "UART4"},
+    {UART5_BASE, SYSCTL_PERIPH_UART5, INT_UART5, "UART5"},
+    {UART6_BASE, SYSCTL_PERIPH_UART6, INT_UART6, "UART6"},
+    {UART7_BASE, SYSCTL_PERIPH_UART7, INT_UART7, "UART7"}
 };
 
 void uart_passthrough(const struct uart_port * port1,
@@ -77,9 +78,7 @@ void uart_passthrough(const struct uart_port * port1,
         UARTRxErrorClear(port1->base);
         if(time_elapsed_ms(&stamp) > timeout && timeout != 0)
         {
-            char error_msg[128 + 2*PATH_MAX]; // adjust size as needed
-            snprintf(error_msg, sizeof(error_msg), "Timeout pending end of break signal. UART passthrough between UART port %s and UART port %s", port1->device_path, port2->device_path);
-            error(FILE_LINE, error_msg);
+            error(FILE_LINE, "Timeout pending end of break signal.");
         }
     }
 }
@@ -314,4 +313,14 @@ void uart_send_break(const struct uart_port * port, uint32_t timeout)
         time_delay_ms(timeout/2);
     }
     UARTBreakCtl(port->base, false);
+}
+
+const char * uart_get_device_path(const struct uart_port * port)
+{
+    if (!port)
+    {
+        error(FILE_LINE, "NULL uart port");
+    }
+
+    return port->device_path;
 }

--- a/nuhal_tiva/src/uart_tiva.c
+++ b/nuhal_tiva/src/uart_tiva.c
@@ -80,7 +80,7 @@ void uart_passthrough(const struct uart_port * port1,
         {
             char error_msg[128 + 2*MAX_LENGTH_UART_DEVICE_PATH]; // adjust size as needed
             snprintf(error_msg, sizeof(error_msg), "Timeout pending end of break signal. Passthrough occurring through UART ports %s and %s.\n Set timeout period: %ld ms\n", uart_get_device_path(port1), uart_get_device_path(port2), timeout);
-            error(FILE_LINE, error_msg);
+            error(FILE_LINE, error_msg); // was not tested and may never be needed since NUC may permanently not need to passthrough main
         }
     }
 }


### PR DESCRIPTION
- Refactored error() function in nuhal_all/src/error.c to accept variable number of args, so uart.c's logic is cleaner (side note: I copy pasted the vsnprintf things to prevent allocating memory for msg, then calling error again and then terminating the program because the second needed < 0 or the second allocation of msg was not possible, so the program never frees the first allocation of msg)
- Changed uart_read_block_error() and uart_write_block() in nuhal_all/src/uart.c to print uart messages in hexidecimal strings rather than directly to strings
- Shrank MAX_LENGTH_UART_DEVICE to be 8 rather than 4096 since uart_tiva.c only initializes uart_ports with name lengths of 5