### PR TITLE
More specific error messages and fixed minor bug #12

### DIFF
--- a/src/common/protocol.c
+++ b/src/common/protocol.c
@@ -226,10 +226,10 @@ bool protocol_read_block_error(const struct uart_port * port,
     protocol_packet_stream_init(out);
 
     // read the header
-    uart_read_block(port, &out->_data[0], HEADER_BYTES,
+    uart_read_block_error(port, &out->_data[0], HEADER_BYTES,
                     0 == timeout ? 0
                     : timeout + TIMEOUT_MS_PER_BYTE * HEADER_BYTES ,
-                    UART_TERM_NONE);
+                    UART_TERM_NONE, timeout_error);
 
     // ACK packets from the bootloader have a length of 0, so that length
     // does not include the header bytes. In all other packets, the length

--- a/src/common/uart.c
+++ b/src/common/uart.c
@@ -80,7 +80,8 @@ int uart_read_block_error(const struct uart_port * port, void * data,
             offset += snprintf(read_hex_msg + offset, sizeof(read_hex_msg) - offset, "%02X ", bytes[i]);
         }
         read_hex_msg[offset] = '\0';
-        error(FILE_LINE, "Timeout on blocking read. Trying to read on UART port %s\nHave read up to: %s (in hex)\nNumber of bytes left to read: %zu", 
+        error(FILE_LINE, "Timeout (waited %lu ms) on blocking read. Trying to read on UART port %s\nHave read up to: %s (in hex)\nNumber of bytes left to read: %zu", 
+            (unsigned long) timeout,
             uart_get_device_path(port), 
             read_hex_msg, 
             len - read);


### PR DESCRIPTION
This pull request addresses issue https://github.com/omnid/omnid_firmware/issues/19.

Changes: 
1. Edited error message in common/uart.c for more specific details printed in UART timeout error
2. Changed common/protocol.c's protocol_read_block_error to timeout when reading header depending on whether user wants a timeout error. Before this change, protocol_read_block_error would give a timeout error upon failure of reading header regardless of user's desire. 

Does not need to be tested and ready to be merged.